### PR TITLE
fix: add support for dimmed gitignored files/folders in Explorer

### DIFF
--- a/themes/ultraViolet.json
+++ b/themes/ultraViolet.json
@@ -109,9 +109,9 @@
         "conflict.background": "#261824",
         "conflict.border": "#E297DB",
 
-        "ignored": "#625C66",
-        "ignored.background": "#1A1A1A",
-        "ignored.border": "#2E2E2E",
+        "ignored": "#6B6576",
+        "ignored.background": "#0B0C10",
+        "ignored.border": "#222226",
 
         "hidden": "#A09AAB",
         "hidden.background": "#1A1A1A",


### PR DESCRIPTION
In the current `ultraViolet` theme, gitignored files/folders in the Explorer don’t appear visually de-emphasized (greyed out), which makes it harder to quickly distinguish ignored content from tracked/untracked files. Other themes (like Tokyo Night) make ignored items much easier to scan by rendering them with a muted color.

Patched ultraViolet
<img width="486" height="150" alt="Image" src="https://github.com/user-attachments/assets/56941cac-f257-4a73-b26b-bc46ef52b746" />

Current ultraViolet
<img width="478" height="152" alt="Image" src="https://github.com/user-attachments/assets/8462d6b2-1238-4787-9c85-506437839c7b" />

Tokyo Night
<img width="484" height="142" alt="Image" src="https://github.com/user-attachments/assets/14c1fa8f-f3fe-4c8a-884b-4315343a2d00" />